### PR TITLE
Starting items tab changes

### DIFF
--- a/app/components/StartingItems.jsx
+++ b/app/components/StartingItems.jsx
@@ -15,6 +15,10 @@ export const StartingItems = ({ settings, setSetting, itemPool }) => {
     setSetting({ startingItems });
   };
 
+  const resetItems = () => {
+    setSetting({ startingItems: {}})
+  };
+
   // Valid gamePrefix are "MM" and "OOT"
   const buildSingleTable = (gamePrefix) => {
     return (
@@ -43,9 +47,12 @@ export const StartingItems = ({ settings, setSetting, itemPool }) => {
   }
 
   return (
-    <div className="starting-items">
-      {buildSingleTable("MM")}
-      {buildSingleTable("OOT")}
-    </div>
+    <React.Fragment>
+      <button className="reset-button" onClick={() => resetItems()}>Reset Starting Items</button>
+      <div className="starting-items">
+        {buildSingleTable("MM")}
+        {buildSingleTable("OOT")}
+      </div>
+    </React.Fragment>
   );
 };

--- a/app/components/StartingItems.jsx
+++ b/app/components/StartingItems.jsx
@@ -25,7 +25,7 @@ export const StartingItems = ({ settings, setSetting, itemPool }) => {
       <table>
         <thead>
           <tr>
-            <th colspan="2">{gamePrefix === "MM" ? "Majora's Mask" : "Ocarina of Time"}</th>
+            <th colSpan="2">{gamePrefix === "MM" ? "Majora's Mask" : "Ocarina of Time"}</th>
           </tr>
         </thead>
         <tbody>

--- a/app/components/StartingItems.jsx
+++ b/app/components/StartingItems.jsx
@@ -25,7 +25,7 @@ export const StartingItems = ({ settings, setSetting, itemPool }) => {
       </thead>
       <tbody>
         {Object.keys(itemPool).map(item =>
-          <tr key={item}>
+          <tr key={item} className={settings.startingItems[item] > 0 ? "active" : "inactive"}>
             <td>{item}</td>
             <td>
               <button onClick={() => alterItem(item, -1)}>-</button>

--- a/app/components/StartingItems.jsx
+++ b/app/components/StartingItems.jsx
@@ -15,26 +15,37 @@ export const StartingItems = ({ settings, setSetting, itemPool }) => {
     setSetting({ startingItems });
   };
 
-  return (
-    <table>
-      <thead>
-        <tr>
-          <th>Item</th>
-          <th>Count</th>
-        </tr>
-      </thead>
-      <tbody>
-        {Object.keys(itemPool).map(item =>
-          <tr key={item} className={settings.startingItems[item] > 0 ? "active" : "inactive"}>
-            <td>{item}</td>
-            <td>
-              <button onClick={() => alterItem(item, -1)}>-</button>
-              {settings.startingItems[item] || 0}
-              <button onClick={() => alterItem(item, 1)}>+</button>
-            </td>
+  // Valid gamePrefix are "MM" and "OOT"
+  const buildSingleTable = (gamePrefix) => {
+    return (
+      <table>
+        <thead>
+          <tr>
+            <th colspan="2">{gamePrefix === "MM" ? "Majora's Mask" : "Ocarina of Time"}</th>
           </tr>
-        )}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {Object.keys(itemPool)
+            .filter(item => item.startsWith(gamePrefix))
+            .map(item =>
+              <tr key={item} className={settings.startingItems[item] > 0 ? "active" : "inactive"}>
+                <td className="count">
+                  <button className="count-adjust" onClick={() => alterItem(item, -1)}>-</button>
+                  {settings.startingItems[item] || 0}
+                  <button className="count-adjust" onClick={() => alterItem(item, 1)}>+</button>
+                </td>
+                <td>{item}</td>
+              </tr>
+            )}
+        </tbody>
+      </table>
+    )
+  }
+
+  return (
+    <div className="starting-items">
+      {buildSingleTable("MM")}
+      {buildSingleTable("OOT")}
+    </div>
   );
 };

--- a/app/index.css
+++ b/app/index.css
@@ -8,3 +8,4 @@
 @import "./style/generator.css";
 @import "./style/tab.css";
 @import "./style/form.css";
+@import "./style/startingitems.css";

--- a/app/style/startingitems.css
+++ b/app/style/startingitems.css
@@ -1,0 +1,4 @@
+tr.active {
+    background-color: #d0d0d0;
+    font-weight: bold;
+}

--- a/app/style/startingitems.css
+++ b/app/style/startingitems.css
@@ -2,3 +2,22 @@ tr.active {
     background-color: #d0d0d0;
     font-weight: bold;
 }
+
+table {
+    display: inline-block;
+    width: 40%;
+}
+
+div.starting-items {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+}
+
+td.count {
+    padding-right: 8px;
+}
+
+button.count-adjust {
+    margin: 0 1px;
+}

--- a/app/style/startingitems.css
+++ b/app/style/startingitems.css
@@ -1,23 +1,23 @@
 .starting-items tr.active {
-    background-color: #d0d0d0;
-    font-weight: bold;
+  background-color: #d0d0d0;
+  font-weight: bold;
 }
 
 .starting-items table {
-    display: inline-block;
-    width: 40%;
+  display: inline-block;
+  width: 40%;
 }
 
 div.starting-items {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-around;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
 }
 
 td.count {
-    padding: 3px 8px 3px 3px;
+  padding: 3px 8px 3px 3px;
 }
 
 button.count-adjust {
-    margin: 0 1px;
+  margin: 0 1px;
 }

--- a/app/style/startingitems.css
+++ b/app/style/startingitems.css
@@ -21,3 +21,19 @@ td.count {
 button.count-adjust {
   margin: 0 1px;
 }
+
+.reset-button {
+  background-color: #f44336;
+  border: none;
+  border-radius: 10px;
+  color: white;
+  padding: 15px 50px;
+  text-align: center;
+  display: inline-block;
+  font-size: 16px;
+  margin: 0 0 20px 50px;
+}
+
+.reset-button:active {
+  opacity: 0.7;
+}

--- a/app/style/startingitems.css
+++ b/app/style/startingitems.css
@@ -1,9 +1,9 @@
-tr.active {
+.starting-items tr.active {
     background-color: #d0d0d0;
     font-weight: bold;
 }
 
-table {
+.starting-items table {
     display: inline-block;
     width: 40%;
 }
@@ -15,7 +15,7 @@ div.starting-items {
 }
 
 td.count {
-    padding-right: 8px;
+    padding: 3px 8px 3px 3px;
 }
 
 button.count-adjust {

--- a/app/style/startingitems.css
+++ b/app/style/startingitems.css
@@ -8,6 +8,15 @@
   width: 40%;
 }
 
+.starting-items th {
+  font-weight: bold;
+  text-decoration: underline;
+  font-size: 150%;
+  text-align: left;
+  padding-bottom: 10px;
+  padding-left: 3px;
+}
+
 div.starting-items {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
I went ahead and tried to make the starting items page on the generator a little easier to use. 
- Separated oot and mm items into separate columns
- Any item that you have marked to start with 1 or more will be highlighted and bold
- Added a reset button that sets all starting items to 0

I also noticed that there is a bug in the function that updates the counts, it doesn't properly remove any starting items that you set to 0 from the settings object. I am going to submit that as a separate PR in case you want to only merge that.

I also want to make nice frontend names for everything. That should be easily doable with a lookup table in core. I am going to submit a PR over there that takes the backend names and uses a lookup table to get a pretty frontend name for everything that is then written to the spoiler log. That lookup table can then be imported in gui and used on this end too.