### PR TITLE
Change starting items tab to clearer frontend names

### DIFF
--- a/app/components/StartingItems.jsx
+++ b/app/components/StartingItems.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { findFrontendItemName } from '@ootmm/core';
+
 export const StartingItems = ({ settings, setSetting, itemPool }) => {
   const alterItem = (item, delta) => {
     const { startingItems } = settings;
@@ -38,7 +40,7 @@ export const StartingItems = ({ settings, setSetting, itemPool }) => {
                   {settings.startingItems[item] || 0}
                   <button className="count-adjust" onClick={() => alterItem(item, 1)}>+</button>
                 </td>
-                <td>{item}</td>
+                <td>{findFrontendItemName(item)}</td>
               </tr>
             )}
         </tbody>


### PR DESCRIPTION
Use the new frontend names in core to replace the names of the items on the starting items tab of the generator. This relies on https://github.com/OoTMM/core/pull/238 or will not work.