### PR TITLE
New h2 styles, new layout min width, clean up

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -44,10 +44,7 @@ export const App = () => {
   return (
     <div>
       <h1>OoTMM Web Generator</h1>
-      <br />
-      <p>Version: {process.env.VERSION}</p>
-      <br />
-      <br />
+      <h2>Version: {process.env.VERSION}</h2>
       {result && (
         <Result rom={result.rom} log={result.log} hash={result.hash} />
       )}

--- a/app/components/Tricks.jsx
+++ b/app/components/Tricks.jsx
@@ -20,7 +20,7 @@ export const Tricks = ({ settings, setSetting }) => {
 
   return (
     <form className="settings">
-      <h1>Ocarina of Time</h1>
+      <h2>Ocarina of Time</h2>
       <div className="checkboxes" style={styles.fistDiv}>
         {ootTricks.map((trick) => (
           <Checkbox
@@ -31,7 +31,7 @@ export const Tricks = ({ settings, setSetting }) => {
           />
         ))}
       </div>
-      <h1>Majora's Mask</h1>
+      <h2>Majora's Mask</h2>
       <div className="checkboxes">
         {mmTricks.map((trick) => (
           <Checkbox

--- a/app/style/_global.css
+++ b/app/style/_global.css
@@ -9,8 +9,6 @@ html, body {
 html {
   font-family: Sailec, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 62.5%;
-  -webkit-font-smoothing: antialiased;
-  text-size-adjust: 100%;
 }
 
 body {
@@ -21,6 +19,12 @@ h1 {
   font-size: 32px;
   line-height: 36px;
   margin-bottom: 0.5rem;
+}
+
+h2 {
+    font-size: 20px;
+    line-height: 28px;
+    margin-bottom: 24px
 }
 
 label {

--- a/app/style/layout.css
+++ b/app/style/layout.css
@@ -1,5 +1,6 @@
 .main {
   width: 90%;
+  min-width: 1024px;
   border: 1px solid #ccc;
   padding: 1em;
   background: #f4f4f4;


### PR DESCRIPTION
New styles for h2 
<img width="1147" alt="image" src="https://user-images.githubusercontent.com/9772365/218514674-0710a911-f63a-4d98-a58f-3f07944924ff.png">

OUT OF SCOPE
I went back to get the original width of the main container and added it as the min-width to prevent the tabs from wrapping.