### PR TITLE
Support disabled spoiler logs

### DIFF
--- a/app/components/Result.jsx
+++ b/app/components/Result.jsx
@@ -15,11 +15,23 @@ const appendHash = (str, hash, ext) => {
   return `${str}.${ext}`;
 };
 
+const generateSpoilerLogWarning = (log) => {
+  if (log === null) {
+    return (<div className='generator-warning'>
+      WARNING: This seed was not generated with a spoiler log. 
+      You will not be able to obtain one later. 
+      If this is a mistake, please generate a new seed.
+    </div>);
+  }
+  return '';
+}
+
 export const Result = ({ rom, log, hash }) => {
   return (
     <div>
       <button onClick={() => download(rom, appendHash('OoTMM', hash, 'z64'), 'application/octet-stream')}>Save ROM</button>
-      <button onClick={() => download(log, appendHash('spoiler', hash, 'txt'), 'text/plain')}>Save Spoiler Log</button>
+      <button disabled={log === null} onClick={() => download(log, appendHash('spoiler', hash, 'txt'), 'text/plain')}>Save Spoiler Log</button>
+      {generateSpoilerLogWarning(log)}
     </div>
   );
 };

--- a/app/style/generator.css
+++ b/app/style/generator.css
@@ -6,6 +6,14 @@
   background: #ffcccc;
 }
 
+.generator-warning {
+  display: block;
+  margin: 1em;
+  padding: 1em;
+  color: #330000;
+  background: #ffe5b2;
+}
+
 .file-select {
   margin: 2em;
   align-items: center;


### PR DESCRIPTION
If the log is disabled, the download log button is disabled. Also print's a warning right below to indicate that a log was not generated with the seed and cannot be obtained later to ensure that the user wanted that.