### PR TITLE
Fix support for shared items on gui

### DIFF
--- a/app/components/StartingItems.jsx
+++ b/app/components/StartingItems.jsx
@@ -21,6 +21,8 @@ export const StartingItems = ({ settings, setSetting, itemPool }) => {
     setSetting({ startingItems: {} });
   };
 
+  console.log(itemPool)
+
   // Valid gamePrefix are "MM" and "OOT"
   const buildSingleTable = (gamePrefix) => {
     return (
@@ -34,7 +36,7 @@ export const StartingItems = ({ settings, setSetting, itemPool }) => {
         </thead>
         <tbody>
           {Object.keys(itemPool)
-            .filter((item) => item.startsWith(gamePrefix))
+            .filter((item) => item.startsWith(gamePrefix) || item.startsWith("SHARED"))
             .map((item) => (
               <tr
                 key={item}


### PR DESCRIPTION
Put shared items onto the gui on both sides. Incrementing it on the MM side also increments the OOT side and vice versa. The names of the magic arrows say (MM) after them but that is the function in the core repo that handles the renaming.